### PR TITLE
Fix an issue that caused errors when trying to install as a system package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ else:
 class CustomInstallCommand(install):
     def run(self):
         # Call parent
-        install.do_egg_install(self)
+        super().run()
 
         # Install the actual profanity-omemo.py to the profanity plugins folder.
         print('do post install stuff here...')

--- a/setup.py
+++ b/setup.py
@@ -28,15 +28,6 @@ else:
     requirements += ['cryptography>=1.1']
 
 
-class CustomInstallCommand(install):
-    def run(self):
-        # Call parent
-        super().run()
-
-        # Install the actual profanity-omemo.py to the profanity plugins folder.
-        print('do post install stuff here...')
-
-
 setup(
     name='profanity-omemo-plugin',
     version='0.0.1',
@@ -73,7 +64,4 @@ setup(
     install_requires=requirements,
     setup_requires=['pytest-runner'],
     tests_require=['pytest', 'mock'],
-
-    # Extend the install command with a post_install command
-    cmdclass={'install': CustomInstallCommand},
 )


### PR DESCRIPTION
Previously, `do_egg_install` was always called.  It should only be called when certain arguments are passed, as `run` does, or else you get errors about `.pth` files when trying to create system packages.