### PR TITLE
Fix tox.ini deprecated arguments and setup.py pycrypto dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ requirements = [
 if platform.python_implementation() == 'PyPy':
     requirements += ['pycrypto']
 else:
-    requirements += ['cryptography>=1.1']
+    requirements += ['cryptography>=1.1', 'pycrypto']
 
 
 class CustomInstallCommand(install):

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py27,py35,py36
 
 [testenv]
-install_command = pip install --process-dependency-links --allow-external --allow-unverified {opts} {packages}
+install_command = pip install --process-dependency-links {opts} {packages}
 commands =
     coverage run --source profanity_omemo_plugin,prof_omemo_plugin setup.py test
     coverage report -m


### PR DESCRIPTION
In tox.ini, pip used deprecated arguments,
see https://pip.pypa.io/en/stable/news/#b1-2018-03-31

In setup.py, non-PyPy installations did not require pycrypto,
but the import of Crypto.* fails if pycrypto is not installed.